### PR TITLE
Added RSS feed

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" type="text/css" href="{{site.baseurl}}/stylesheets/reset.css">
   <link rel="stylesheet" type="text/css" href="{{site.baseurl}}/stylesheets/screen.css">
 
+  <!-- RSS feed -->
+  <link rel="alternate" type="application/rss+xml" title="18F Agile Delivery Services BPA Feed" href="/feed.xml" />
+
   <meta name="viewport" content="width=device-width">
   <!--[if lt IE 9]>
     <script src="{{ site.baseurl }}/assets/js/html5shiv.js"></script>

--- a/data/orders.yml
+++ b/data/orders.yml
@@ -7,6 +7,8 @@
   repository: 'https://github.com/18F/bpa-fedramp-dashboard'
   description: |
     The scope of this task order is for the Contractor to deliver the public beta launch of the Federal Risk and Authorization Management Program (FedRAMP) dashboard.
+  date_posted: 2016-05-14
+  date_updated: 2016-05-14
 - requesting_agency: General Services Administration
   office: 18F
   rfq_id: null
@@ -14,6 +16,8 @@
   solicitation_date: (2016-05)
   period_of_performance: TBD
   repository: null
+  date_posted: 2016-05-14
+  date_updated: 2016-05-14
 - requesting_agency: Environmental Protection Agency
   office: Office of Land and Emergency Management
   rfq_id: null
@@ -21,6 +25,8 @@
   solicitation_date: (2016-05)
   period_of_performance: TBD
   repository: null
+  date_posted: 2016-05-14
+  date_updated: 2016-05-14
 - requesting_agency: Department of Labor
   office: Wage and Hour Division
   rfq_id: null
@@ -28,3 +34,5 @@
   solicitation_date: (2016-05)
   period_of_performance: TBD
   repository: null
+  date_posted: 2016-05-14
+  date_updated: 2016-05-14

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,24 @@
+---
+
+---
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <link href="https://pages.18f.gov/ads-bpa/feed.xml" rel="self" type="application/atom+xml"/>
+  <link href="https://pages.18f.gov/ads-bpa/" rel="alternate" type="text/html"/>
+  <updated>{{site.time | date_to_xmlschema }}</updated>
+  <id>https://pages.18f.gov/ads-bpa/</id>
+  <title>18F Digital Services Delivery</title>
+  <subtitle>
+    18F builds effective, user-centric digital services focused on the interaction between government and the people and businesses it serves.
+  </subtitle>
+  {% for bpa in site.data.orders %}
+  <entry>
+    <title>{{ bpa.title }}</title>
+    <author>18F Acquisitions</author>
+    <published>{{ bpa.date_posted }}T00:00:00-04:00</published>
+    <updated>{{ bpa.date_updated }}T00:00:00-04:00</updated>
+    <id>https://pages.18f.gov/ads-bpa/</id>
+    <content type="html"><h1>{{bpa.title}} for {{bpa.office}} - {{bpa.requesting_agency}}</h1>{% if bpa.description %}<div>Description: {{bpa.description}}</div>{% endif %}<div>Period of performance: {{bpa.period_of_performance}}</div><div>Estimated solicitation date: {{bpa.solicitation_date}}</div>{% if bpa.rfq_id %}<div>RFQ ID: {{bpa.rfq_id}}</div>{% endif %}{% if bpa.repository %}<div>Repository: {{bpa.repository}}</div>{% endif %}</content>
+    <summary>{{bpa.title}} for {{bpa.office}} - {{bpa.requesting_agency}}</summary>
+  </entry>
+  {% endfor %}
+</feed>


### PR DESCRIPTION
This commit will substitute for the PR submitted by @stnvrlly here:
https://github.com/18F/ads-bpa/pull/19/

The reason for the new commit is to maintain the data directory and the
data that's included in the most up-to-date branch.

This commit does the following:
1. Creates a feed.xml RSS feed;
2. Adds the link to the RSS feed in the head element; and
3. Updates the data file for orders to include the `date_posted` and
   `date_updated` fields.
