### PR TITLE
updated to data_dir

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,4 +38,4 @@ repos:
 google_analytics_ua: UA-48605964-19
 
 # Data Source
-data_source: data
+data_dir: data


### PR DESCRIPTION
Apparently `data_source` is deprecated and now `data_dir` is the way to configure a data directory.
