### PR TITLE
added state to bpa orders

### DIFF
--- a/_includes/solicitation.html
+++ b/_includes/solicitation.html
@@ -1,0 +1,41 @@
+<li>
+  <dl class="solicitation">
+  {{order.Requesting_Agency}}
+    <dt class="solicitation-id">ID</dt>
+    <dd class="solicitation-id">{% if order.rfq_id %}#{{order.rfq_id}}{%else%}TBD{% endif %}</dd>
+    <dt class="solicitation-title">Title</dt>
+    <dd class="solicitation-title"><h1>{{order.title}}</h1></dd>
+    <dt class="solicitation-agency">Agency</dt>
+    <dd class="solicitation-agency">{{order.requesting_agency}}</dd>
+    <dt class="solicitation-office">Office</dt>
+    <dd class="solicitation-office">{{order.office}}</dd>
+    <dt class="solicitation-date">{%if order.state == "planning" %}Anticipated s {% else %}S{% endif %}olicitation date</dt>
+    <dd class="solicitation-date"><time datetime="{{order.solicitation_date}}}">{{order.solicitation_date | date: "%B %d, %Y" }}</time></dd>
+    <dt class="solicitation-period-of-performance">Period of performance</dt>
+    <dd class="solicitation-period-of-performance">{{order.period_of_performance}}</dd>
+    {% if order.description %}
+    <dt class="solicitation-description">Description</dt>
+    <dd class="solicitation-description">
+    <p>{{order.description}}</p>
+    </dd>
+    {% endif %}
+    {% if order.award_data %}
+
+    <dt class="solicitation-description">Award information</dt>
+    <dd class="solicitation-description">
+      <p>Vendor: {{order.award_data.vendor}}</p>
+      <p>Amount: {{order.award_data.amount}}</p>
+      <p>Number of Bidders: {{order.award_data.bidders}}</p>
+      <p>Median: {{order.award_data.median}}</p>
+      <p>Mean: {{order.award_data.mean}}</p>
+      <p>Standard Deviation: {{order.award_data.stdev}}</p>
+      <p>Award Date: <time datetime="{{order.award_data.date}}}">{{order.award_data.date | date: "%B %d, %Y" }}</time></p>
+    </dd>
+    {% endif %}
+
+    {% if order.repository %}
+    <dt class="solicitation-repository">Repository</dt>
+    <dd class="solicitation-repository"><a href="{{order.repository}}">GitHub</a></p></dd>
+    {% endif %}
+  </dl>
+</li>

--- a/data/orders.yml
+++ b/data/orders.yml
@@ -9,6 +9,7 @@
     The scope of this task order is for the Contractor to deliver the public beta launch of the Federal Risk and Authorization Management Program (FedRAMP) dashboard.
   date_posted: 2016-05-14
   date_updated: 2016-05-14
+  state: delivered
   award_data:
     vendor: TrueTandem​
     amount: "$153,782.05"
@@ -37,6 +38,7 @@
     date: 2016-09-09
   date_posted: 2016-05-14
   date_updated: 2016-09-09
+  state: awarded
 - requesting_agency: Department of Labor
   office: Wage and Hour Division
   rfq_id: 1110470
@@ -46,7 +48,7 @@
   repository: https://github.com/18F/bpa-DOL-WHD-14-c-
   description: |
     Section 14(c) permits the payment of subminimum wage rates, after receipt of a certificate by DOL, to individuals whose earning or productive capacity is impaired by a disability for the work to be performed. It requires that an individual’s rate of pay be commensurate with the rates paid workers without a disability performing the same type of work in the same vicinity.
-    
+
     The 14(c) system will become a modern, digital-first service. Applicants will be provided an intuitive online experience, guiding them through the information needed to complete their application correctly. Applicants will have the ability to save their progress along the way, submit it to the system and see their application status. The application data will be made available to WHD users to inform certification and enforcement decisions. Applicants will have access to previous applications in order to apply for renewal. The product will support policy and process evolution over time, and will support data transparency wherever and however possible.
   date_posted: 2016-05-14
   award_data:
@@ -58,6 +60,7 @@
     stdev: "$91,179.57"
     date: 2016-09-09
   date_updated: 2016-09-09
+  state: awarded
 - requesting_agency: Environmental Protection Agency
   office: Office of Land and Emergency Management
   rfq_id: null
@@ -67,9 +70,10 @@
   repository: null
   date_posted: 2016-05-14
   date_updated: 2016-05-14
+  state: planning
 - requesting_agency: Office of Personnel Management
   office: Federal Investigative Services (FIS)
-  rfq_id: 1138886 
+  rfq_id: 1138886
   title: e-QIP Refresh Prototyping
   solicitation_date: 2016-09-06
   period_of_performance: |
@@ -79,3 +83,4 @@
     A prototype design and development project to refresh the Electronic Questionnaires for Investigations Processing (e-QIP) system.
   date_posted: 2016-07-10
   date_updated: 2016-09-06
+  state: posted

--- a/pages/index.md
+++ b/pages/index.md
@@ -5,50 +5,36 @@ title: Introduction and updates
 ---
 
 <section class="solicitations">
-  <h1>Upcoming solicitations</h1>
-  <ol class="solicitations">
+  <h1>Posted for Bid</h1>
+  <ol class="solicitations posted">
   {% for order in site.data.orders %}
-    <li>
-      <dl class="solicitation">
-      {{order.Requesting_Agency}}
-        <dt class="solicitation-id">ID</dt>
-        <dd class="solicitation-id">{% if order.rfq_id %}#{{order.rfq_id}}{%else%}TBD{% endif %}</dd>
-        <dt class="solicitation-title">Title</dt>
-        <dd class="solicitation-title"><h1>{{order.title}}</h1></dd>
-        <dt class="solicitation-agency">Agency</dt>
-        <dd class="solicitation-agency">{{order.requesting_agency}}</dd>
-        <dt class="solicitation-office">Office</dt>
-        <dd class="solicitation-office">{{order.office}}</dd>
-        <dt class="solicitation-date">Anticipated solicitation date</dt>
-        <dd class="solicitation-date"><time datetime="{{order.solicitation_date}}}">{{order.solicitation_date | date: "%B %d, %Y" }}</time></dd>
-        <dt class="solicitation-period-of-performance">Period of performance</dt>
-        <dd class="solicitation-period-of-performance">{{order.period_of_performance}}</dd>
-        {% if order.description %}
-        <dt class="solicitation-description">Description</dt>
-        <dd class="solicitation-description">
-        <p>{{order.description}}</p>
-        </dd>
-        {% endif %}
-        {% if order.award_data %}
-
-        <dt class="solicitation-description">Award information</dt>
-        <dd class="solicitation-description">
-          <p>Vendor: {{order.award_data.vendor}}</p>
-          <p>Amount: {{order.award_data.amount}}</p>
-          <p>Number of Bidders: {{order.award_data.bidders}}</p>
-          <p>Median: {{order.award_data.median}}</p>
-          <p>Mean: {{order.award_data.mean}}</p>
-          <p>Standard Deviation: {{order.award_data.stdev}}</p>
-          <p>Award Date: <time datetime="{{order.award_data.date}}}">{{order.award_data.date | date: "%B %d, %Y" }}</time></p>
-        </dd>
-        {% endif %}
-
-        {% if order.repository %}
-        <dt class="solicitation-repository">Repository</dt>
-        <dd class="solicitation-repository"><a href="{{order.repository}}">GitHub</a></p></dd>
-        {% endif %}
-      </dl>
-    </li>
+    {% if order.state == "posted" %}
+      {% include solicitation.html %}
+    {% endif %}
+  {% endfor %}
+  </ol>
+  <h1>Awarded</h1>
+  <ol class="solicitations awarded">
+  {% for order in site.data.orders %}
+    {% if order.state == "awarded" %}
+      {% include solicitation.html %}
+    {% endif %}
+  {% endfor %}
+  </ol>
+  <h1>Delivered</h1>
+  <ol class="solicitations delivered">
+  {% for order in site.data.orders %}
+    {% if order.state == "delivered" %}
+      {% include solicitation.html %}
+    {% endif %}
+  {% endfor %}
+  </ol>
+  <h1>Planning</h1>
+  <ol class="solicitations planning">
+  {% for order in site.data.orders %}
+    {% if order.state == "planning" %}
+      {% include solicitation.html %}
+    {% endif %}
   {% endfor %}
   </ol>
 </section>
@@ -60,7 +46,7 @@ title: Introduction and updates
     <p>18F partnered with the General Service Administration (GSA) <a href="https://www.gsa.gov/portal/content/105150">Office of Integrated Technology Services</a> to establish a <a href="http://www.gsa.gov/portal/content/199353">blanket purchase agreement (BPA)</a> featuring vendors specializing in agile delivery services (e.g., user-centered design, agile software development, DevOps). The <strong>Agile Delivery Services BPA (Agile BPA)</strong> represents an effort to align acquisition practices with agile delivery practices.</p>
     <p>The Agile BPA is different from most other traditional IT services contract vehicles. It uses <a href="https://18f.gsa.gov/2015/04/23/coming-soon-the-agile-delivery-services-soliciatation/">novel ways to select vendors</a>: the most important thing for us is the ability to ship high-quality working software. We plan to issue task orders &mdash; consistent with the <a href="https://playbook.cio.gov/techfar/">TechFAR</a> &mdash; that feature shorter time-frames, smaller dollar amounts, and user-centered design principles.</div>
     <p>We use an <strong>iterative and incremental</strong> approach to the use of agile procurement. This will allow us to focus on building the appropriate processes and tools, and help us scale over time.</p>
-    <h2>Learn more as a </h2>
+    <h1>Learn more as a </h1>
     <ul class="learn-more">
       <li class="learn-more-federal-agency"><a href="buyers/">Federal agency interested in buying services</a></li>
       <li class="learn-more-vendor"><a href="vendors/">Vendor</a></li>


### PR DESCRIPTION
In this PR, I do the following:
- Add a "state" field to each order in the `orders.yml` file
- Move the hard-coded html for the solicitation into a partial in the `_includes` directory
- Divide the home page based on the order's state
- Fix "anticipated solicitation date" to "solicitation date" where the status is not "planning" 
