### PR TITLE
Fixing DOL status

### DIFF
--- a/data/orders.yml
+++ b/data/orders.yml
@@ -60,7 +60,7 @@
     stdev: "$91,179.57"
     date: 2016-09-09
   date_updated: 2016-09-09
-  state: delievered
+  state: delivered
 - requesting_agency: Environmental Protection Agency
   office: Office of Land and Emergency Management
   rfq_id: null


### PR DESCRIPTION
Spelling error of delievered to delivered, may be why pages.18f isn't showing the solicitation/delivery of DOL 14(c).