### PR TITLE
Generate badges for orders

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,13 @@ repos:
 - name: Agile Delivery Services BPA Guide
   description: Main repository
 
+page_gen:
+  - data: orders
+    template: badges
+    name: title
+    dir: badges
+    extension: svg
+
 google_analytics_ua: UA-48605964-19
 
 # Data Source

--- a/_includes/solicitation.html
+++ b/_includes/solicitation.html
@@ -35,7 +35,7 @@
 
     {% if order.repository %}
     <dt class="solicitation-repository">Solicitation Repository</dt>
-    <dd class="solicitation-repository"><a href="{{order.repository}}">GitHub</a></p></dd>
+    <dd class="solicitation-repository"><a href="{{order.repository}}">GitHub</a> | <img src="badges/{{order.title | datapage_url}}.svg"></p></dd>
     {% endif %}
   </dl>
 </li>

--- a/_layouts/badges.html
+++ b/_layouts/badges.html
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="120" height="20">
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="a">
+    <rect width="120" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#a)">
+    <path fill="#555" d="M0 0h63v20H0z"/>
+    <path fill="{% if page.state == 'planning' %}#fe7d37{% elsif page.state == 'posted' %}#dfb317{% elsif page.state == 'awarded' %}#97ca00{% else %}#007ec6{% endif %}" d="M63 0h57v20H63z"/>
+    <path fill="url(#b)" d="M0 0h120v20H0z"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
+    <text x="325" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="530">TTS aBPA</text>
+    <text x="325" y="140" transform="scale(.1)" textLength="530">TTS aBPA</text>
+    <text x="905" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="470">awarded</text>
+    <text x="905" y="140" transform="scale(.1)" textLength="470">{{page.state}}</text>
+  </g>
+</svg>

--- a/_layouts/badges.html
+++ b/_layouts/badges.html
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
     <text x="325" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="530">TTS aBPA</text>
     <text x="325" y="140" transform="scale(.1)" textLength="530">TTS aBPA</text>
-    <text x="905" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="470">awarded</text>
+    <text x="905" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="470">{{page.state}}</text>
     <text x="905" y="140" transform="scale(.1)" textLength="470">{{page.state}}</text>
   </g>
 </svg>

--- a/_plugins/data_page_generator.rb
+++ b/_plugins/data_page_generator.rb
@@ -1,0 +1,122 @@
+# Generate pages from individual records in yml files
+# (c) 2014-2016 Adolfo Villafiorita
+# Distributed under the conditions of the MIT License
+
+module Jekyll
+
+  module Sanitizer
+    # strip characters and whitespace to create valid filenames, also lowercase
+    def sanitize_filename(name)
+      if(name.is_a? Integer)
+        return name.to_s
+      end
+      return name.tr(
+  "ÀÁÂÃÄÅàáâãäåĀāĂăĄąÇçĆćĈĉĊċČčÐðĎďĐđÈÉÊËèéêëĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħÌÍÎÏìíîïĨĩĪīĬĭĮįİıĴĵĶķĸĹĺĻļĽľĿŀŁłÑñŃńŅņŇňŉŊŋÑñÒÓÔÕÖØòóôõöøŌōŎŏŐőŔŕŖŗŘřŚśŜŝŞşŠšſŢţŤťŦŧÙÚÛÜùúûüŨũŪūŬŭŮůŰűŲųŴŵÝýÿŶŷŸŹźŻżŽž",
+  "AAAAAAaaaaaaAaAaAaCcCcCcCcCcDdDdDdEEEEeeeeEeEeEeEeEeGgGgGgGgHhHhIIIIiiiiIiIiIiIiIiJjKkkLlLlLlLlLlNnNnNnNnnNnNnOOOOOOooooooOoOoOoRrRrRrSsSsSsSssTtTtTtUUUUuuuuUuUuUuUuUuUuWwYyyYyYZzZzZz"
+).downcase.strip.gsub(' ', '-').gsub(/[^\w.-]/, '')
+    end
+  end
+
+  # this class is used to tell Jekyll to generate a page
+  class DataPage < Page
+    include Sanitizer
+
+    # - site and base are copied from other plugins: to be honest, I am not sure what they do
+    #
+    # - `index_files` specifies if we want to generate named folders (true) or not (false)
+    # - `dir` is the default output directory
+    # - `data` is the data defined in `_data.yml` of the record for which we are generating a page
+    # - `name` is the key in `data` which determines the output filename
+    # - `template` is the name of the template for generating the page
+    # - `extension` is the extension for the generated file
+    def initialize(site, base, index_files, dir, data, name, template, extension)
+      @site = site
+      @base = base
+
+      # @dir is the directory where we want to output the page
+      # @name is the name of the page to generate
+      #
+      # the value of these variables changes according to whether we
+      # want to generate named folders or not
+      filename = sanitize_filename(data[name]).to_s
+      @dir = dir + (index_files ? "/" + filename + "/" : "")
+      @name = (index_files ? "index" : filename) + "." + extension.to_s
+
+      self.process(@name)
+      self.read_yaml(File.join(base, '_layouts'), template + ".html")
+      self.data['title'] = data[name]
+      # add all the information defined in _data for the current record to the
+      # current page (so that we can access it with liquid tags)
+      self.data.merge!(data)
+    end
+  end
+
+  class DataPagesGenerator < Generator
+    safe true
+
+    # generate loops over _config.yml/page_gen invoking the DataPage
+    # constructor for each record for which we want to generate a page
+
+    def generate(site)
+      # page_gen_dirs determines whether we want to generate index pages
+      # (name/index.html) or standard files (name.html). This information
+      # is passed to the DataPage constructor, which sets the @dir variable
+      # as required by this directive
+      index_files = site.config['page_gen-dirs'] == true
+
+      # data contains the specification of the data for which we want to generate
+      # the pages (look at the README file for its specification)
+      data = site.config['page_gen']
+      if data
+        data.each do |data_spec|
+          template = data_spec['template'] || data_spec['data']
+          name = data_spec['name']
+          dir = data_spec['dir'] || data_spec['data']
+          extension = data_spec['extension'] || "html"
+
+          if site.layouts.key? template
+            # records is the list of records defined in _data.yml
+            # for which we want to generate different pages
+            records = nil
+            data_spec['data'].split('.').each do |level|
+              if records.nil?
+                records = site.data[level]
+              else
+                records = records[level]
+              end
+            end
+            records = records.select { |r| r[data_spec['filter']] } if data_spec['filter']
+            records.each do |record|
+              site.pages << DataPage.new(site, site.source, index_files, dir, record, name, template, extension)
+            end
+          else
+            puts "error. could not find template #{template}" if not site.layouts.key? template
+          end
+        end
+      end
+    end
+  end
+
+  module DataPageLinkGenerator
+    include Sanitizer
+
+    # use it like this: {{input | datapage_url: dir}}
+    # to generate a link to a data_page.
+    #
+    # the filter is smart enough to generate different link styles
+    # according to the data_page-dirs directive ...
+    #
+    # ... however, the filter is not smart enough to support different
+    # extensions for filenames.
+    #
+    # Thus, if you use the `extension` feature of this plugin, you
+    # need to generate the links by hand
+    def datapage_url(input, dir)
+      extension = Jekyll.configuration({})['page_gen-dirs'] ? '/' : '.html'
+      "#{dir}/#{sanitize_filename(input)}#{extension}"
+    end
+  end
+
+end
+
+Liquid::Template.register_filter(Jekyll::DataPageLinkGenerator)

--- a/_plugins/data_page_generator.rb
+++ b/_plugins/data_page_generator.rb
@@ -100,17 +100,11 @@ module Jekyll
   module DataPageLinkGenerator
     include Sanitizer
 
-    # use it like this: {{input | datapage_url: dir}}
+    # use it like this: {{input | datapage_url}}
     # to generate a link to a data_page.
     #
-    # the filter is smart enough to generate different link styles
-    # according to the data_page-dirs directive ...
-    #
-    # ... however, the filter is not smart enough to support different
-    # extensions for filenames.
-    #
-    # Thus, if you use the `extension` feature of this plugin, you
-    # need to generate the links by hand
+    # Simplified from the original version to meet
+    # our more limited needs.
     def datapage_url(input)
       "#{sanitize_filename(input)}"
     end

--- a/_plugins/data_page_generator.rb
+++ b/_plugins/data_page_generator.rb
@@ -111,9 +111,8 @@ module Jekyll
     #
     # Thus, if you use the `extension` feature of this plugin, you
     # need to generate the links by hand
-    def datapage_url(input, dir)
-      extension = Jekyll.configuration({})['page_gen-dirs'] ? '/' : '.html'
-      "#{dir}/#{sanitize_filename(input)}#{extension}"
+    def datapage_url(input)
+      "#{sanitize_filename(input)}"
     end
   end
 


### PR DESCRIPTION
This PR adds a plugin that allows us to create content based on items in the `data` directory.  I built a template for creating SVG badges and modified the config to create a badge per order in `data/orders.yml`.  The badges have static URLs, so they can be added to our BPA Github READMEs.

The solicitation template is also updated so that any solicitation which currently has a repo will also display the badge, to make it easy to get a link to the image.

Here are what the badges look like:

![planning svg](https://user-images.githubusercontent.com/1775733/33858095-0510f0d4-de94-11e7-82c1-c642f166763f.png)
![posted svg](https://user-images.githubusercontent.com/1775733/33858096-07e34d0c-de94-11e7-977a-2b22814e989f.png)
![awarded svg](https://user-images.githubusercontent.com/1775733/33858099-0a6580d6-de94-11e7-843d-cb78edf214b6.png)
![delivered svg](https://user-images.githubusercontent.com/1775733/33858100-0a73f580-de94-11e7-92ee-52c6dab3469f.png)

And here's what the solicitation looks like on the main ADS site, with the badge added next to the repo link:

![screen shot 2017-12-11 at 4 49 47 pm](https://user-images.githubusercontent.com/1775733/33858130-1d6e8e16-de94-11e7-8cdb-340f04a829c1.png)
